### PR TITLE
Improve type safety in groupedSchedule reducer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 # You could use a local API (https://github.com/comuline/api) or the production API (https://www.api.comuline.com/v1/)
-API_URL="https://www.comuline.com/v1"
+API_URL="https://www.api.comuline.com/v1"

--- a/src/commons/ui/sections/station-item.tsx
+++ b/src/commons/ui/sections/station-item.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { Schedule, GroupedSchedule } from "@/commons/type";
+import type { GroupedSchedule } from "@/commons/type";
 import * as Accordion from "@/commons/ui/components/accordion";
 import { cn } from "@/commons/utils/cn";
 import {
@@ -35,7 +35,7 @@ const StationItem = ({
   });
 
   const groupedSchedule: GroupedSchedule = data?.reduce(
-    (acc: Record<string, Record<string, Schedule[]>>, obj) => {
+    (acc: GroupedSchedule, obj) => {
       const lineKey = `${obj.line}-${obj.color}`;
       const destKey = obj.destination;
 

--- a/src/commons/ui/sections/station-item.tsx
+++ b/src/commons/ui/sections/station-item.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type GroupedSchedule } from "@/commons/type";
+import type { Schedule, GroupedSchedule } from "@/commons/type";
 import * as Accordion from "@/commons/ui/components/accordion";
 import { cn } from "@/commons/utils/cn";
 import {
@@ -34,26 +34,26 @@ const StationItem = ({
         : undefined,
   });
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const groupedSchedule: GroupedSchedule = data?.reduce((acc: any, obj) => {
-    const lineKey = `${obj.line}-${obj.color}`;
-    const destKey = obj.destination;
+  const groupedSchedule: GroupedSchedule = data?.reduce(
+    (acc: Record<string, Record<string, Schedule[]>>, obj) => {
+      const lineKey = `${obj.line}-${obj.color}`;
+      const destKey = obj.destination;
 
-    if (!acc[lineKey]) {
-      acc[lineKey] = {};
-    }
+      const lineKeyRecord = acc[lineKey] ?? {};
+      const destKeyArray = lineKeyRecord[destKey] ?? [];
 
-    if (!acc[lineKey][destKey]) {
-      acc[lineKey][destKey] = [];
-    }
+      destKeyArray.push({
+        ...obj,
+        timeEstimated: removeSeconds(obj.timeEstimated),
+        destinationTime: removeSeconds(obj.destinationTime),
+      });
 
-    acc[lineKey][destKey].push({
-      ...obj,
-      timeEstimated: removeSeconds(obj.timeEstimated),
-      destinationTime: removeSeconds(obj.destinationTime),
-    });
-    return acc;
-  }, {});
+      lineKeyRecord[destKey] = destKeyArray;
+      acc[lineKey] = lineKeyRecord;
+      return acc;
+    },
+    {},
+  );
 
   useEffect(() => {
     if (isLoading) return;


### PR DESCRIPTION
This PR removes the need for this line of comment by properly typing the accumulator.
```
  // eslint-disable-next-line @typescript-eslint/no-explicit-any
```

An additional change is introduced at `.env.example` to point at the correct production API.