### PR TITLE
fix: schedule order

### DIFF
--- a/src/components/station-item.tsx
+++ b/src/components/station-item.tsx
@@ -72,10 +72,16 @@ const ScheduleLine = ({
         ) : null}
       </div>
       {(() => {
-        const moreSchedules = (groupedSchedule[lineKey]?.[destKey] ?? []).slice(
-          1,
-          5,
-        );
+        const filteredSchedules = groupedSchedule[lineKey]?.[destKey] ?? [];
+        const sortedSchedules = filteredSchedules.toSorted((a, b) => {
+          // sorting schedules ignoring the date part
+          const dateA = new Date(a.departs_at);
+          const dateB = new Date(b.departs_at);
+          const timeA = dateA.getHours() * 60 + dateA.getMinutes();
+          const timeB = dateB.getHours() * 60 + dateB.getMinutes();
+          return timeA - timeB;
+        });
+        const moreSchedules = sortedSchedules.slice(1, 5);
 
         return moreSchedules.length > 0 ? (
           moreSchedules.length < 4 ? (
@@ -126,7 +132,7 @@ const ScheduleLine = ({
                 </Accordion.Trigger>
                 <Accordion.Content className="flex gap-1 text-left">
                   <div className="grid w-full grid-cols-2 gap-1.5 md:grid-cols-4 md:gap-2">
-                    {(groupedSchedule[lineKey]?.[destKey] ?? [])
+                    {sortedSchedules
                       .slice(5)
                       .map((train) => (
                         <div key={train.id} className="flex flex-col gap-0.5">


### PR DESCRIPTION
i think the data provided by the api is sorted by updated_at by default, so currently it's not ordered properly.
<img width="528" alt="image" src="https://github.com/user-attachments/assets/4177097d-9a0b-4eee-b1e4-b1c006769c9e" />

this fix added sorting schedules manually based on `departs_at`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Schedule times are now displayed in chronological order, ensuring a clearer and more intuitive presentation for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->